### PR TITLE
fix: Revert postcss.config.js to standard configuration

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 export default {
   plugins: {
-    'tailwindcss/nesting': {},
     tailwindcss: {},
     autoprefixer: {},
   },


### PR DESCRIPTION
This commit reverts the `postcss.config.js` file to its standard configuration. The previous change to add `tailwindcss/nesting` was incorrect and caused a build failure.

The actual fix for the original PostCSS issue was the installation of the `@tailwindcss/postcss` package, which works with the standard configuration.