### PR TITLE
fix: Correct CardTitle component ref type

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -27,7 +27,7 @@ const CardHeader = React.forwardRef<
 CardHeader.displayName = "CardHeader"
 
 const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
+  HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h3


### PR DESCRIPTION
This commit fixes a TypeScript type mismatch in the `CardTitle` component. The `ref` was incorrectly typed as `HTMLParagraphElement` while being forwarded to an `<h3>` element. This has been corrected to `HTMLHeadingElement`.