### PR TITLE
fix: Add defensive check for icon rendering in PageCard

### DIFF
--- a/src/components/layout/PageCard.tsx
+++ b/src/components/layout/PageCard.tsx
@@ -35,7 +35,7 @@ const PageCard: React.FC<PageCardProps> = ({ code, title, description, to, type,
         <CardHeader>
           <div className="flex justify-between items-center mb-4">
             <div className={`p-2 rounded-lg ${iconColors[type]}`}>
-              <Icon className="w-6 h-6" />
+              {Icon && <Icon className="w-6 h-6" />}
             </div>
             <Badge variant="outline" className={typeColors[type]}>{code}</Badge>
           </div>


### PR DESCRIPTION
This commit adds a conditional check to the `PageCard` component. It will now only attempt to render the icon if the `icon` prop is a truthy value. This is a defensive measure to prevent the application from crashing due to the `Element type is invalid` error and should help visually identify which module's icon is being passed as `undefined`.