### PR TITLE
fix: Replace hardcoded overlays with global state-managed system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react-router-dom": "^7.8.2",
         "recharts": "^3.1.2",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -5747,6 +5748,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-router-dom": "^7.8.2",
     "recharts": "^3.1.2",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -1,22 +1,30 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Outlet, Link, useLocation } from 'react-router-dom';
 import { Home, Workflow, BarChart3, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useOverlayStore } from '@/stores/overlay';
+import Overlay from '@/components/ui/Overlay';
 
 const navItems = [
   { path: '/', icon: Home, label: 'Home' },
   { path: '/workflow-editor', icon: Workflow, label: 'Workflows' },
   { path: '/performance-dashboard', icon: BarChart3, label: 'Analytics' },
-  { path: '/help', icon: Settings, label: 'Help' }, // Assuming settings might be in help
+  { path: '/help', icon: Settings, label: 'Help' },
 ];
 
 const RootLayout: React.FC = () => {
   const location = useLocation();
+  const { isAnyOverlayOpen, closeAll } = useOverlayStore();
+
+  // Close any overlays when the route changes
+  useEffect(() => {
+    closeAll();
+  }, [location.pathname, closeAll]);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
       {/* Left Navigation */}
-      <nav className="w-16 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col items-center py-4">
+      <nav className="w-16 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col items-center py-4 z-20">
         <Link to="/" className="w-8 h-8 mb-8">
           <svg className="w-8 h-8" viewBox="0 0 64 64">
             <defs>
@@ -59,9 +67,12 @@ const RootLayout: React.FC = () => {
       </nav>
 
       {/* Main Content */}
-      <main className="flex-1">
+      <main className="flex-1 relative z-10">
         <Outlet />
       </main>
+
+      {/* Global Overlay */}
+      <Overlay open={isAnyOverlayOpen} onClick={closeAll} />
     </div>
   );
 };

--- a/src/components/ui/Overlay.tsx
+++ b/src/components/ui/Overlay.tsx
@@ -1,0 +1,22 @@
+import { memo } from "react";
+
+type Props = {
+  open: boolean;
+  onClick?: () => void;
+};
+
+const Overlay = memo(function Overlay({ open, onClick }: Props) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      onClick={onClick}
+      className="fixed inset-0 z-40 bg-black/40 transition-opacity"
+    />
+  );
+});
+
+export default Overlay;

--- a/src/pages/ExportCenterPage.tsx
+++ b/src/pages/ExportCenterPage.tsx
@@ -182,11 +182,25 @@ const ExportCard = ({ exportItem, isSelected, onSelect }) => {
   );
 };
 
+import { useOverlayStore } from '@/stores/overlay';
+import { useEffect } from 'react';
+
 // New Export Dialog Component
 const NewExportDialog = ({ isOpen, onClose }) => {
+  const { open, closeAll } = useOverlayStore();
   const [selectedFormat, setSelectedFormat] = useState('json');
   const [exportName, setExportName] = useState('');
   const [version, setVersion] = useState('1.0.0');
+
+  useEffect(() => {
+    if (isOpen) {
+      open();
+    } else {
+      closeAll();
+    }
+    // Cleanup on unmount
+    return () => closeAll();
+  }, [isOpen, open, closeAll]);
 
   if (!isOpen) return null;
 
@@ -198,20 +212,25 @@ const NewExportDialog = ({ isOpen, onClose }) => {
     { id: 'openapi', name: 'API Bundle', description: 'OpenAPI YAML specification' }
   ];
 
+  const handleClose = () => {
+    closeAll();
+    onClose();
+  };
+
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4" data-testid="new-export-dialog">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden">
+    <div className="fixed inset-0 flex items-center justify-center z-50 p-4" data-testid="new-export-dialog">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <div>
             <h2 className="text-xl font-bold text-gray-900">Create New Export</h2>
             <p className="text-sm text-gray-600 mt-1">Generate export artifacts from your designs</p>
           </div>
-          <Button variant="ghost" onClick={onClose}>
+          <Button variant="ghost" onClick={handleClose}>
             <FileText className="w-5 h-5" />
           </Button>
         </div>
 
-        <div className="p-6 space-y-6">
+        <div className="p-6 space-y-6 overflow-y-auto">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">Export Name</label>
             <input
@@ -271,7 +290,7 @@ const NewExportDialog = ({ isOpen, onClose }) => {
             Export will be generated and ready for download
           </div>
           <div className="flex space-x-3">
-            <Button variant="outline" onClick={onClose}>
+            <Button variant="outline" onClick={handleClose}>
               Cancel
             </Button>
             <Button className="bg-[#256C3A] hover:bg-[#1e5530] text-white">

--- a/src/pages/ScenarioTemplateGalleryPage.tsx
+++ b/src/pages/ScenarioTemplateGalleryPage.tsx
@@ -153,21 +153,44 @@ const TemplateCard = ({ template, isSelected, onSelect, onPreview }) => {
   );
 };
 
+import { useOverlayStore } from '@/stores/overlay';
+import { useEffect } from 'react';
+
 // Template Preview Modal
 const TemplatePreviewModal = ({ template, isOpen, onClose, onApply }) => {
+  const { open, closeAll } = useOverlayStore();
   const [activeTab, setActiveTab] = useState('overview');
+
+  useEffect(() => {
+    if (isOpen) {
+      open();
+    } else {
+      closeAll();
+    }
+    return () => closeAll();
+  }, [isOpen, open, closeAll]);
 
   if (!isOpen || !template) return null;
 
+  const handleClose = () => {
+    closeAll();
+    onClose();
+  };
+
+  const handleApply = () => {
+    closeAll();
+    onApply(template);
+  };
+
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" data-testid="template-preview-modal">
-      <div className="bg-white rounded-xl shadow-xl max-w-4xl w-full mx-4 max-h-[90vh] overflow-hidden">
+    <div className="fixed inset-0 flex items-center justify-center z-50 p-4" data-testid="template-preview-modal">
+      <div className="bg-white rounded-xl shadow-xl max-w-4xl w-full mx-4 max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex items-center justify-between p-6 border-b border-gray-200">
           <div>
             <h2 className="text-xl font-bold text-gray-900">{template.name}</h2>
             <p className="text-sm text-gray-600 mt-1">{template.description}</p>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+          <button onClick={handleClose} className="text-gray-400 hover:text-gray-600">
             <X className="w-6 h-6" />
           </button>
         </div>
@@ -284,11 +307,11 @@ const TemplatePreviewModal = ({ template, isOpen, onClose, onApply }) => {
             Estimated duration: {template.duration} • {template.robotsRequired} robots required
           </div>
           <div className="flex space-x-3">
-            <Button variant="outline" onClick={onClose}>
+            <Button variant="outline" onClick={handleClose}>
               Cancel
             </Button>
             <Button 
-              onClick={() => onApply(template)}
+              onClick={handleApply}
               className="bg-[#256C3A] hover:bg-[#1e5530] text-white"
             >
               <Play className="w-4 h-4 mr-2" />

--- a/src/pages/TemplateGalleryPage.tsx
+++ b/src/pages/TemplateGalleryPage.tsx
@@ -220,26 +220,37 @@ const TemplateCard = ({ template, isSelected, onSelect, onPreview }) => {
   );
 };
 
+import { useOverlayStore } from '@/stores/overlay';
+
 // Enhanced Template Preview Modal
 const TemplatePreviewModal = ({ template, isOpen, onClose, onApply }) => {
+  const { open, closeAll } = useOverlayStore();
   const [activeTab, setActiveTab] = useState('overview');
 
   useEffect(() => {
     if (isOpen) {
-      document.body.style.overflow = 'hidden';
+      open();
     } else {
-      document.body.style.overflow = 'unset';
+      closeAll();
     }
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen]);
+    return () => closeAll();
+  }, [isOpen, open, closeAll]);
 
   if (!isOpen || !template) return null;
 
+  const handleClose = () => {
+    closeAll();
+    onClose();
+  };
+
+  const handleApply = () => {
+    closeAll();
+    onApply(template);
+  };
+
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4" data-testid="template-preview-modal">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-5xl w-full max-h-[90vh] overflow-hidden animate-in fade-in-0 zoom-in-95 duration-300">
+    <div className="fixed inset-0 flex items-center justify-center z-50 p-4" data-testid="template-preview-modal">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-5xl w-full max-h-[90vh] overflow-hidden animate-in fade-in-0 zoom-in-95 duration-300 flex flex-col">
         <div className="flex items-center justify-between p-6 border-b border-gray-200 bg-gray-50">
           <div className="flex items-center space-x-4">
             <div className="w-12 h-12 bg-gradient-to-br from-[#256C3A] to-[#1e5530] rounded-xl flex items-center justify-center shadow-lg">
@@ -258,7 +269,7 @@ const TemplatePreviewModal = ({ template, isOpen, onClose, onApply }) => {
               <Maximize2 className="w-5 h-5 text-gray-500" />
             </button>
             <button 
-              onClick={onClose} 
+              onClick={handleClose}
               className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
             >
               <X className="w-5 h-5 text-gray-500" />
@@ -293,7 +304,7 @@ const TemplatePreviewModal = ({ template, isOpen, onClose, onApply }) => {
           })}
         </div>
 
-        <div className="p-6 overflow-y-auto max-h-96">
+        <div className="p-6 overflow-y-auto flex-1">
           {activeTab === 'overview' && (
             <div className="space-y-6" data-testid="overview-tab">
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -389,11 +400,11 @@ const TemplatePreviewModal = ({ template, isOpen, onClose, onApply }) => {
             <span className="font-medium"> Robots required:</span> {template.robotsRequired}
           </div>
           <div className="flex space-x-3">
-            <Button variant="outline" onClick={onClose} className="border-gray-300">
+            <Button variant="outline" onClick={handleClose} className="border-gray-300">
               Cancel
             </Button>
             <Button 
-              onClick={() => onApply(template)}
+              onClick={handleApply}
               className="bg-[#256C3A] hover:bg-[#1e5530] text-white shadow-sm"
             >
               <Play className="w-4 h-4 mr-2" />

--- a/src/stores/overlay.ts
+++ b/src/stores/overlay.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type OverlayStore = {
+  isAnyOverlayOpen: boolean;
+  open: () => void;
+  closeAll: () => void;
+};
+
+export const useOverlayStore = create<OverlayStore>((set) => ({
+  isAnyOverlayOpen: false,
+  open: () => set({ isAnyOverlayOpen: true }),
+  closeAll: () => set({ isAnyOverlayOpen: false }),
+}));


### PR DESCRIPTION
Removes hardcoded `fixed inset-0` overlays from individual page components and implements a new, centralized overlay system.

- Adds a `zustand` store to manage the global overlay state.
- Creates a reusable `<Overlay />` component that renders based on the store.
- Integrates the overlay system into the main `RootLayout`, ensuring it closes on navigation.
- Refactors modals in `ExportCenterPage`, `ScenarioTemplateGalleryPage`, and `TemplateGalleryPage` to use the new global store, fixing the persistent overlay bug.