### PR TITLE
fix: Separate layouts for site and app routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import RootLayout from './components/layout/RootLayout';
+import AppLayout from './components/layout/AppLayout';
+import SiteLayout from './components/layout/SiteLayout';
 import IndexPage from './pages/IndexPage';
 import DashboardPage from './pages/DashboardPage';
 import MapEditorPage from './pages/MapEditorPage';
@@ -16,59 +17,63 @@ import HelpTutorialsPage from './pages/HelpTutorialsPage';
 
 const router = createBrowserRouter([
   {
-    path: '/',
-    element: <RootLayout />,
+    element: <SiteLayout />,
     children: [
       {
-        index: true,
+        path: '/',
         element: <IndexPage />,
       },
+    ],
+  },
+  {
+    element: <AppLayout />,
+    children: [
       {
-        path: 'dashboard',
+        path: '/dashboard',
         element: <DashboardPage />,
       },
       {
-        path: 'map-editor',
+        path: '/map-editor',
         element: <MapEditorPage />,
       },
       {
-        path: 'workflow-editor',
+        path: '/workflow-editor',
         element: <WorkflowEditorPage />,
       },
       {
-        path: 'simulation-viewer',
+        path: '/simulation-viewer',
         element: <SimulationViewerPage />,
       },
       {
-        path: 'mission-scheduler',
+        path: '/mission-scheduler',
         element: <MissionSchedulerPage />,
       },
       {
-        path: 'robot-library',
+        path: '/robot-library',
         element: <RobotLibraryManagerPage />,
       },
       {
-        path: 'scenario-templates',
+        path: '/scenario-templates',
         element: <ScenarioTemplateGalleryPage />,
       },
       {
-        path: 'design-export',
+        path: '/design-export',
         element: <ExportCenterPage />,
       },
       {
-        path: 'performance-dashboard',
+        path: '/performance-dashboard',
         element: <PerformanceDashboardPage />,
       },
       {
-        path: 'safety-validation',
+        path: '/safety-validation',
         element: <CollisionSafetyPage />,
       },
       {
-        path: 'developer-tools',
+        path: '/developer-tools',
         element: <ApiToolsPage />,
       },
       {
-        path: 'help',
+        path: '/help',
         element: <HelpTutorialsPage />,
       },
     ],

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -12,7 +12,7 @@ const navItems = [
   { path: '/help', icon: Settings, label: 'Help' },
 ];
 
-const RootLayout: React.FC = () => {
+const AppLayout: React.FC = () => {
   const location = useLocation();
   const { isAnyOverlayOpen, closeAll } = useOverlayStore();
 
@@ -77,4 +77,4 @@ const RootLayout: React.FC = () => {
   );
 };
 
-export default RootLayout;
+export default AppLayout;

--- a/src/components/layout/SiteLayout.tsx
+++ b/src/components/layout/SiteLayout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const SiteLayout: React.FC = () => {
+  return (
+    <div className="min-h-screen">
+      <Outlet />
+    </div>
+  );
+};
+
+export default SiteLayout;

--- a/src/pages/ApiToolsPage.tsx
+++ b/src/pages/ApiToolsPage.tsx
@@ -421,39 +421,6 @@ const APIToolsPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="api-tools-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-6 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="mb-8">
-          <FarmFlowFavicon />
-        </div>
-        
-        <div className="flex flex-col space-y-3">
-          {[
-            { icon: Home, id: 'dashboard', active: false },
-            { icon: Workflow, id: 'workflows', active: false },
-            { icon: BarChart3, id: 'analytics', active: false },
-            { icon: Calendar, id: 'scheduler', active: false },
-            { icon: Package, id: 'library', active: false },
-            { icon: Star, id: 'templates', active: false },
-            { icon: Shield, id: 'safety', active: false },
-            { icon: Code, id: 'api', active: true },
-            { icon: Settings, id: 'settings', active: false }
-          ].map(({ icon: Icon, id, active }) => (
-            <button 
-              key={id}
-              className={`w-12 h-12 rounded-xl flex items-center justify-center transition-all duration-200 ${
-                active 
-                  ? 'bg-[#256C3A] text-white shadow-lg shadow-[#256C3A]/25 scale-105' 
-                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 hover:scale-105'
-              }`}
-              data-testid={`nav-${id}`}
-            >
-              <Icon className="w-5 h-5" />
-            </button>
-          ))}
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/CollisionSafetyPage.tsx
+++ b/src/pages/CollisionSafetyPage.tsx
@@ -455,39 +455,6 @@ const CollisionSafetyValidation = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="collision-safety-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-6 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="mb-8">
-          <FarmFlowFavicon />
-        </div>
-        
-        <div className="flex flex-col space-y-3">
-          {[
-            { icon: Home, id: 'dashboard', active: false },
-            { icon: Workflow, id: 'workflows', active: false },
-            { icon: BarChart3, id: 'analytics', active: false },
-            { icon: Calendar, id: 'scheduler', active: false },
-            { icon: Package, id: 'library', active: false },
-            { icon: Star, id: 'templates', active: false },
-            { icon: Download, id: 'exports', active: false },
-            { icon: Shield, id: 'safety', active: true },
-            { icon: Settings, id: 'settings', active: false }
-          ].map(({ icon: Icon, id, active }) => (
-            <button 
-              key={id}
-              className={`w-12 h-12 rounded-xl flex items-center justify-center transition-all duration-200 ${
-                active 
-                  ? 'bg-[#256C3A] text-white shadow-lg shadow-[#256C3A]/25 scale-105' 
-                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 hover:scale-105'
-              }`}
-              data-testid={`nav-${id}`}
-            >
-              <Icon className="w-5 h-5" />
-            </button>
-          ))}
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/ExportCenterPage.tsx
+++ b/src/pages/ExportCenterPage.tsx
@@ -409,38 +409,6 @@ const ExportCenter = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="export-center-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-6 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="mb-8">
-          <FarmFlowFavicon />
-        </div>
-        
-        <div className="flex flex-col space-y-3">
-          {[
-            { icon: Home, id: 'dashboard', active: false },
-            { icon: Workflow, id: 'workflows', active: false },
-            { icon: BarChart3, id: 'analytics', active: false },
-            { icon: Calendar, id: 'scheduler', active: false },
-            { icon: Package, id: 'library', active: false },
-            { icon: Star, id: 'templates', active: false },
-            { icon: Download, id: 'exports', active: true },
-            { icon: Settings, id: 'settings', active: false }
-          ].map(({ icon: Icon, id, active }) => (
-            <button 
-              key={id}
-              className={`w-12 h-12 rounded-xl flex items-center justify-center transition-all duration-200 ${
-                active 
-                  ? 'bg-[#256C3A] text-white shadow-lg shadow-[#256C3A]/25 scale-105' 
-                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 hover:scale-105'
-              }`}
-              data-testid={`nav-${id}`}
-            >
-              <Icon className="w-5 h-5" />
-            </button>
-          ))}
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/HelpTutorialsPage.tsx
+++ b/src/pages/HelpTutorialsPage.tsx
@@ -530,40 +530,6 @@ const HelpTutorialsPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="help-tutorials-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-6 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="mb-8">
-          <FarmFlowFavicon />
-        </div>
-        
-        <div className="flex flex-col space-y-3">
-          {[
-            { icon: Home, id: 'dashboard', active: false },
-            { icon: Workflow, id: 'workflows', active: false },
-            { icon: BarChart3, id: 'analytics', active: false },
-            { icon: Calendar, id: 'scheduler', active: false },
-            { icon: Package, id: 'library', active: false },
-            { icon: Star, id: 'templates', active: false },
-            { icon: Shield, id: 'safety', active: false },
-            { icon: Code, id: 'api', active: false },
-            { icon: HelpCircle, id: 'help', active: true },
-            { icon: Settings, id: 'settings', active: false }
-          ].map(({ icon: Icon, id, active }) => (
-            <button 
-              key={id}
-              className={`w-12 h-12 rounded-xl flex items-center justify-center transition-all duration-200 ${
-                active 
-                  ? 'bg-[#256C3A] text-white shadow-lg shadow-[#256C3A]/25 scale-105' 
-                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 hover:scale-105'
-              }`}
-              data-testid={`nav-${id}`}
-            >
-              <Icon className="w-5 h-5" />
-            </button>
-          ))}
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/MissionSchedulerPage.tsx
+++ b/src/pages/MissionSchedulerPage.tsx
@@ -222,46 +222,6 @@ const MissionScheduler = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="mission-scheduler-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-4 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="w-8 h-8 mb-8">
-          <svg className="w-8 h-8" viewBox="0 0 64 64">
-            <defs>
-              <linearGradient id="navBg" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style={{stopColor:'#256C3A'}}/>
-                <stop offset="100%" style={{stopColor:'#1e5530'}}/>
-              </linearGradient>
-            </defs>
-            <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#navBg)"/>
-            <rect x="16" y="36" width="4" height="12" fill="white" rx="2"/>
-            <rect x="22" y="32" width="4" height="16" fill="white" rx="2"/>
-            <rect x="28" y="28" width="4" height="20" fill="white" rx="2"/>
-            <rect x="34" y="24" width="4" height="24" fill="white" rx="2"/>
-            <rect x="40" y="30" width="4" height="18" fill="white" rx="2"/>
-            <circle cx="48" cy="20" r="4" fill="white"/>
-            <rect x="46" y="18" width="4" height="4" fill="#256C3A" rx="1"/>
-          </svg>
-        </div>
-        
-        <div className="flex flex-col space-y-4">
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-dashboard">
-            <Home className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-workflows">
-            <Workflow className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-simulation">
-            <BarChart3 className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg bg-[#256C3A] text-white flex items-center justify-center shadow-md" data-testid="nav-scheduler">
-            <Calendar className="w-5 h-5 fill-current" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-settings">
-            <Settings className="w-5 h-5" />
-          </button>
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/PerformanceDashboardPage.tsx
+++ b/src/pages/PerformanceDashboardPage.tsx
@@ -275,37 +275,6 @@ const PerformanceDashboard = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="performance-dashboard-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-6 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="mb-8">
-          <FarmFlowFavicon />
-        </div>
-        
-        <div className="flex flex-col space-y-3">
-          {[
-            { icon: Home, id: 'dashboard', active: false },
-            { icon: Workflow, id: 'workflows', active: false },
-            { icon: BarChart3, id: 'analytics', active: true },
-            { icon: Calendar, id: 'scheduler', active: false },
-            { icon: Package, id: 'library', active: false },
-            { icon: Star, id: 'templates', active: false },
-            { icon: Settings, id: 'settings', active: false }
-          ].map(({ icon: Icon, id, active }) => (
-            <button 
-              key={id}
-              className={`w-12 h-12 rounded-xl flex items-center justify-center transition-all duration-200 ${
-                active 
-                  ? 'bg-[#256C3A] text-white shadow-lg shadow-[#256C3A]/25 scale-105' 
-                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 hover:scale-105'
-              }`}
-              data-testid={`nav-${id}`}
-            >
-              <Icon className="w-5 h-5" />
-            </button>
-          ))}
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/RobotLibraryManagerPage.tsx
+++ b/src/pages/RobotLibraryManagerPage.tsx
@@ -316,49 +316,6 @@ const RobotLibraryManager = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="robot-library-manager-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-4 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="w-8 h-8 mb-8">
-          <svg className="w-8 h-8" viewBox="0 0 64 64">
-            <defs>
-              <linearGradient id="navBg" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style={{stopColor:'#256C3A'}}/>
-                <stop offset="100%" style={{stopColor:'#1e5530'}}/>
-              </linearGradient>
-            </defs>
-            <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#navBg)"/>
-            <rect x="16" y="36" width="4" height="12" fill="white" rx="2"/>
-            <rect x="22" y="32" width="4" height="16" fill="white" rx="2"/>
-            <rect x="28" y="28" width="4" height="20" fill="white" rx="2"/>
-            <rect x="34" y="24" width="4" height="24" fill="white" rx="2"/>
-            <rect x="40" y="30" width="4" height="18" fill="white" rx="2"/>
-            <circle cx="48" cy="20" r="4" fill="white"/>
-            <rect x="46" y="18" width="4" height="4" fill="#256C3A" rx="1"/>
-          </svg>
-        </div>
-        
-        <div className="flex flex-col space-y-4">
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-dashboard">
-            <Home className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-workflows">
-            <Workflow className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-simulation">
-            <BarChart3 className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-scheduler">
-            <Calendar className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg bg-[#256C3A] text-white flex items-center justify-center shadow-md" data-testid="nav-library">
-            <Package className="w-5 h-5 fill-current" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-settings">
-            <Settings className="w-5 h-5" />
-          </button>
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/ScenarioTemplateGalleryPage.tsx
+++ b/src/pages/ScenarioTemplateGalleryPage.tsx
@@ -526,52 +526,6 @@ const ScenarioTemplateGallery = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="scenario-template-gallery-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-4 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="w-8 h-8 mb-8">
-          <svg className="w-8 h-8" viewBox="0 0 64 64">
-            <defs>
-              <linearGradient id="navBg" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style={{stopColor:'#256C3A'}}/>
-                <stop offset="100%" style={{stopColor:'#1e5530'}}/>
-              </linearGradient>
-            </defs>
-            <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#navBg)"/>
-            <rect x="16" y="36" width="4" height="12" fill="white" rx="2"/>
-            <rect x="22" y="32" width="4" height="16" fill="white" rx="2"/>
-            <rect x="28" y="28" width="4" height="20" fill="white" rx="2"/>
-            <rect x="34" y="24" width="4" height="24" fill="white" rx="2"/>
-            <rect x="40" y="30" width="4" height="18" fill="white" rx="2"/>
-            <circle cx="48" cy="20" r="4" fill="white"/>
-            <rect x="46" y="18" width="4" height="4" fill="#256C3A" rx="1"/>
-          </svg>
-        </div>
-        
-        <div className="flex flex-col space-y-4">
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-dashboard">
-            <Home className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-workflows">
-            <Workflow className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-simulation">
-            <BarChart3 className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-scheduler">
-            <Calendar className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-library">
-            <Package className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg bg-[#256C3A] text-white flex items-center justify-center shadow-md" data-testid="nav-templates">
-            <Star className="w-5 h-5 fill-current" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-settings">
-            <Settings className="w-5 h-5" />
-          </button>
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/SimulationViewerPage.tsx
+++ b/src/pages/SimulationViewerPage.tsx
@@ -260,46 +260,6 @@ const SimulationViewer = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="simulation-viewer-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-4 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="w-8 h-8 mb-8">
-          <svg className="w-8 h-8" viewBox="0 0 64 64">
-            <defs>
-              <linearGradient id="navBg" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style={{stopColor:'#256C3A'}}/>
-                <stop offset="100%" style={{stopColor:'#1e5530'}}/>
-              </linearGradient>
-            </defs>
-            <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#navBg)"/>
-            <rect x="16" y="36" width="4" height="12" fill="white" rx="2"/>
-            <rect x="22" y="32" width="4" height="16" fill="white" rx="2"/>
-            <rect x="28" y="28" width="4" height="20" fill="white" rx="2"/>
-            <rect x="34" y="24" width="4" height="24" fill="white" rx="2"/>
-            <rect x="40" y="30" width="4" height="18" fill="white" rx="2"/>
-            <circle cx="48" cy="20" r="4" fill="white"/>
-            <rect x="46" y="18" width="4" height="4" fill="#256C3A" rx="1"/>
-          </svg>
-        </div>
-        
-        <div className="flex flex-col space-y-4">
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-dashboard">
-            <Home className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-workflows">
-            <Workflow className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg bg-[#256C3A] text-white flex items-center justify-center shadow-md" data-testid="nav-simulation">
-            <Play className="w-5 h-5 fill-current" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-analytics">
-            <BarChart3 className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-settings">
-            <Settings className="w-5 h-5" />
-          </button>
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/TemplateGalleryPage.tsx
+++ b/src/pages/TemplateGalleryPage.tsx
@@ -541,37 +541,6 @@ const ScenarioTemplateGallery = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="scenario-template-gallery-page">
-      {/* Enhanced Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-6 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="mb-8">
-          <FarmFlowFavicon />
-        </div>
-        
-        <div className="flex flex-col space-y-3">
-          {[
-            { icon: Home, id: 'dashboard', active: false },
-            { icon: Workflow, id: 'workflows', active: false },
-            { icon: BarChart3, id: 'simulation', active: false },
-            { icon: Calendar, id: 'scheduler', active: false },
-            { icon: Package, id: 'library', active: false },
-            { icon: Star, id: 'templates', active: true },
-            { icon: Settings, id: 'settings', active: false }
-          ].map(({ icon: Icon, id, active }) => (
-            <button 
-              key={id}
-              className={`w-12 h-12 rounded-xl flex items-center justify-center transition-all duration-200 ${
-                active 
-                  ? 'bg-[#256C3A] text-white shadow-lg shadow-[#256C3A]/25 scale-105' 
-                  : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 hover:scale-105'
-              }`}
-              data-testid={`nav-${id}`}
-            >
-              <Icon className="w-5 h-5" />
-            </button>
-          ))}
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         <div className="flex-1 flex flex-col">

--- a/src/pages/WorkflowEditorPage.tsx
+++ b/src/pages/WorkflowEditorPage.tsx
@@ -390,43 +390,6 @@ const WorkflowEditor = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 flex" data-testid="workflow-editor-page">
-      {/* Left Navigation */}
-      <nav className="w-16 bg-white border-r border-gray-200 flex flex-col items-center py-4 shadow-sm" data-testid="left-nav" role="navigation">
-        <div className="w-8 h-8 mb-8">
-          <svg className="w-8 h-8" viewBox="0 0 64 64">
-            <defs>
-              <linearGradient id="navBg" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" style={{stopColor:'#256C3A'}}/>
-                <stop offset="100%" style={{stopColor:'#1e5530'}}/>
-              </linearGradient>
-            </defs>
-            <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#navBg)"/>
-            <rect x="16" y="36" width="4" height="12" fill="white" rx="2"/>
-            <rect x="22" y="32" width="4" height="16" fill="white" rx="2"/>
-            <rect x="28" y="28" width="4" height="20" fill="white" rx="2"/>
-            <rect x="34" y="24" width="4" height="24" fill="white" rx="2"/>
-            <rect x="40" y="30" width="4" height="18" fill="white" rx="2"/>
-            <circle cx="48" cy="20" r="4" fill="white"/>
-            <rect x="46" y="18" width="4" height="4" fill="#256C3A" rx="1"/>
-          </svg>
-        </div>
-        
-        <div className="flex flex-col space-y-4">
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-dashboard" aria-label="Dashboard">
-            <Home className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg bg-[#256C3A] text-white flex items-center justify-center shadow-md" data-testid="nav-workflows" aria-label="Workflows">
-            <Workflow className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-analytics" aria-label="Analytics">
-            <BarChart3 className="w-5 h-5" />
-          </button>
-          <button className="w-10 h-10 rounded-lg text-gray-500 hover:bg-gray-100 flex items-center justify-center transition-colors" data-testid="nav-settings" aria-label="Settings">
-            <Settings className="w-5 h-5" />
-          </button>
-        </div>
-      </nav>
-
       {/* Main Content */}
       <main className="flex-1 flex" data-testid="main-content" role="main">
         {/* Content Area */}


### PR DESCRIPTION
Implements a two-layout system to solve the sidebar visibility issue.

- Renames `RootLayout` to `AppLayout`.
- Creates a new `SiteLayout` for sidebar-less pages.
- Updates the router to use the correct layout for the index page vs. internal app pages.
- Removes all hardcoded sidebars from individual page components.